### PR TITLE
US 2 - Replaced `Flask-SSLify` with `Talisman`

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -2,7 +2,7 @@ from os import environ
 from bleach import clean
 from flask import Flask, render_template, request, redirect, url_for, session
 from werkzeug.exceptions import HTTPException, abort
-from flask_sslify import SSLify
+from flask_talisman import Talisman
 
 from app.Database.DatabaseConnector import DatabaseConnector
 from app.Database.DatabaseManipulator import DatabaseManipulator
@@ -10,9 +10,9 @@ from app.Database.DatabaseManipulator import DatabaseManipulator
 app = Flask(__name__)
 app.secret_key = environ.get('SECRET_KEY')
 
-# Only trigger SSLify if the app is running on Heroku
+# Only trigger Talisman if the app is running on Heroku
 if 'DYNO' in environ:
-    sslify = SSLify(app)
+    Talisman(app)
 
 # Instantiate the DatabaseManipulator
 dbm = DatabaseManipulator()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mysql-connector-python~=8.0.26
 responses~=0.14.0
 Werkzeug~=2.0.2
 bcrypt~=3.2.0
-Flask-SSLify~=0.1.5
+flask-talisman~=0.8.1


### PR DESCRIPTION
- After committing, I soon realized that `Flask-SSLify` was deprecated, and the developers of Flask recommended using `Talisman` instead
- I refactored my code to reflect this change